### PR TITLE
feat: add a Legacy Titlebar toggle to desktop settings

### DIFF
--- a/src/components/sidebar/pages/desktop_page.vala
+++ b/src/components/sidebar/pages/desktop_page.vala
@@ -759,6 +759,12 @@ namespace Singularity {
                 settings.set_boolean("force-ssd", ssd_row.switch_btn.active);
             });
             wm_group.add_row(ssd_row);
+
+            var legacy_row = new SwitchRow(_("Legacy Titlebar"), _("Use a classic titlebar with inline buttons instead of floating hover controls (requires app restart)"), settings.get_boolean("legacy-titlebar"));
+            legacy_row.switch_btn.notify["active"].connect(() => {
+                settings.set_boolean("legacy-titlebar", legacy_row.switch_btn.active);
+            });
+            wm_group.add_row(legacy_row);
             add_group(wm_group);
 
             // Host GTK window decoration layout (titlebar buttons)


### PR DESCRIPTION
Hey! 👋 This is the Settings half of a small, opt-in **Legacy Titlebar** feature requested in singularityos-lab/singularity-desktop#29.

### What this PR does
Adds a **"Legacy Titlebar"** switch under **Settings → Desktop → Window Management**, right alongside the existing decoration options. It's bound to the new `legacy-titlebar` key.

When enabled, Singularity apps render a classic static titlebar instead of the floating hover controls (the subtitle notes it requires an app restart, matching the SSD toggle's behaviour). When off — the default — nothing changes.

### Part of a 3-repo set
- 🎛️ Settings toggle → **this PR**
- 🪟 window render path → singularityos-lab/libsingularity#4
- 🧩 schema key → singularityos-lab/singularity-desktop#31 (closes #29)

It's a tiny change and follows the `ssd_row` pattern right above it. Happy to tweak the label/wording or placement if you'd like it elsewhere. Thanks for the look! 🙏
