### PR TITLE
Fix screenshot format handling and targeted UI captures

### DIFF
--- a/src/core/screenshot_tool.vala
+++ b/src/core/screenshot_tool.vala
@@ -220,7 +220,7 @@ namespace Singularity {
             _target_connector = null;
 
             if (focused_handle != null) {
-                _target_monitor = Singularity.wayland_get_window_monitor(focused_handle);
+                _target_monitor = resolve_monitor_for_window(focused_handle);
             }
             if (_target_monitor == null) {
                 _target_monitor = Singularity.Panel.find_primary_monitor();
@@ -232,6 +232,75 @@ namespace Singularity {
                 _target_connector = _target_monitor.get_connector();
                 GtkLayerShell.set_monitor(this, _target_monitor);
             }
+        }
+
+        private Gdk.Monitor? resolve_monitor_for_window(void* handle) {
+            int x, y, w, h, maximized, fullscreen;
+            string? connector;
+            bool got_geometry = Singularity.wayland_get_window_geometry(handle,
+                out x, out y, out w, out h, out maximized, out fullscreen, out connector);
+
+            if (got_geometry && w > 0 && h > 0) {
+                var monitor = monitor_for_connector(connector);
+                if (monitor != null) return monitor;
+
+                monitor = monitor_for_geometry(x, y, w, h);
+                if (monitor != null) return monitor;
+            }
+
+            return Singularity.wayland_get_window_monitor(handle);
+        }
+
+        private Gdk.Monitor? monitor_for_connector(string? connector) {
+            if (connector == null || connector == "") return null;
+
+            var display = Gdk.Display.get_default();
+            if (display == null) return null;
+
+            var monitors = display.get_monitors();
+            for (uint i = 0; i < monitors.get_n_items(); i++) {
+                var monitor = monitors.get_item(i) as Gdk.Monitor;
+                if (monitor == null) continue;
+                if (monitor.get_connector() == connector) return monitor;
+            }
+            return null;
+        }
+
+        private Gdk.Monitor? monitor_for_geometry(int x, int y, int w, int h) {
+            var display = Gdk.Display.get_default();
+            if (display == null) return null;
+
+            var monitors = display.get_monitors();
+            int center_x = x + (w / 2);
+            int center_y = y + (h / 2);
+            Gdk.Monitor? best_monitor = null;
+            int best_area = 0;
+
+            for (uint i = 0; i < monitors.get_n_items(); i++) {
+                var monitor = monitors.get_item(i) as Gdk.Monitor;
+                if (monitor == null) continue;
+
+                var geo = monitor.get_geometry();
+                if (center_x >= geo.x && center_x < geo.x + geo.width &&
+                    center_y >= geo.y && center_y < geo.y + geo.height) {
+                    return monitor;
+                }
+
+                int ix1 = x > geo.x ? x : geo.x;
+                int iy1 = y > geo.y ? y : geo.y;
+                int ix2 = (x + w) < (geo.x + geo.width) ? (x + w) : (geo.x + geo.width);
+                int iy2 = (y + h) < (geo.y + geo.height) ? (y + h) : (geo.y + geo.height);
+                int iw = ix2 - ix1;
+                int ih = iy2 - iy1;
+                int area = (iw > 0 && ih > 0) ? iw * ih : 0;
+
+                if (area > best_area) {
+                    best_area = area;
+                    best_monitor = monitor;
+                }
+            }
+
+            return best_monitor;
         }
 
         private void on_take_clicked() {

--- a/src/core/screenshot_tool.vala
+++ b/src/core/screenshot_tool.vala
@@ -1,6 +1,7 @@
 using GLib;
 using Gtk;
 using Gee;
+using GtkLayerShell;
 
 namespace Singularity {
 
@@ -18,6 +19,8 @@ namespace Singularity {
         private ulong screenshot_handler_id = 0;
         private bool _pending_region = false;
         private bool _pending_window = false;
+        private Gdk.Monitor? _target_monitor = null;
+        private string? _target_connector = null;
         private Gee.HashMap<uint, string> _screenshot_notification_actions = new Gee.HashMap<uint, string>();
 
         public static ScreenshotTool get_default(Gtk.Application? app = null) {
@@ -211,6 +214,26 @@ namespace Singularity {
             }
         }
 
+        public void prepare_for_invocation(void* focused_handle) {
+            this.focused_handle = focused_handle;
+            _target_monitor = null;
+            _target_connector = null;
+
+            if (focused_handle != null) {
+                _target_monitor = Singularity.wayland_get_window_monitor(focused_handle);
+            }
+            if (_target_monitor == null) {
+                _target_monitor = Singularity.Panel.find_primary_monitor();
+            }
+            if (_target_monitor == null) {
+                _target_monitor = first_monitor();
+            }
+            if (_target_monitor != null) {
+                _target_connector = _target_monitor.get_connector();
+                GtkLayerShell.set_monitor(this, _target_monitor);
+            }
+        }
+
         private void on_take_clicked() {
             int delay_secs = current_delay();
 
@@ -323,7 +346,7 @@ namespace Singularity {
             } else if (_pending_window) {
                 _do_window();
             } else {
-                _do_fullscreen();
+                _do_screen();
             }
         }
 
@@ -355,25 +378,14 @@ namespace Singularity {
             ).open_dialog();
         }
 
-        private void _do_fullscreen() {
-            var portal = ScreenshotPortal.get_default();
-            if (screenshot_handler_id != 0) {
-                portal.disconnect(screenshot_handler_id);
-                screenshot_handler_id = 0;
+        private void _do_screen(bool show_failure = true) {
+            var args = target_monitor_capture_args();
+            if (args == null) {
+                warning("[ScreenshotTool] no target monitor for screen capture");
+                if (show_failure) _show_unavailable_dialog();
+                return;
             }
-            screenshot_handler_id = portal.screenshot_taken.connect((uri) => {
-                if (screenshot_handler_id != 0) {
-                    portal.disconnect(screenshot_handler_id);
-                    screenshot_handler_id = 0;
-                }
-                var file = GLib.File.new_for_uri(uri);
-                string? path = file.get_path();
-                if (path != null) portal.copy_to_clipboard(path);
-                portal.save_to_pictures(uri);
-                Singularity.Shell.ScreenFlash.flash();
-                _notify_screenshot("Saved and copied to clipboard", path);
-            });
-            portal.take_screenshot.begin(false);
+            run_local_screenshot(args, "Saved and copied to clipboard", false, show_failure);
         }
 
         private void _do_region() {
@@ -400,70 +412,124 @@ namespace Singularity {
         private void _do_window() {
             void* handle = focused_handle;
             if (handle == null) {
-                _do_fullscreen();
+                _do_screen();
                 return;
             }
-            var app_system = AppSystem.get_default();
-            var win = app_system.get_window_by_handle(handle);
-            if (win == null || win.snap_type == 0) {
-                _do_fullscreen();
+
+            int x, y, w, h, maximized, fullscreen;
+            string? connector;
+            bool got_geometry = Singularity.wayland_get_window_geometry(handle,
+                out x, out y, out w, out h, out maximized, out fullscreen, out connector);
+            if (!got_geometry || w <= 0 || h <= 0) {
+                warning("[ScreenshotTool] no valid focused window geometry, falling back to monitor");
+                _do_screen();
                 return;
             }
-            var monitors = Gdk.Display.get_default().get_monitors();
-            var monitor = monitors.get_item(0) as Gdk.Monitor;
-            if (monitor == null) { _do_fullscreen(); return; }
-            var mon = monitor.get_geometry();
-            int mw = mon.width;
-            int mh = mon.height;
 
-            int panel_h = app_system.shell_panel_height;
-            int dock_h = app_system.shell_dock_height;
-            int uw = mw;
-            int uh = mh - panel_h - dock_h;
-            int ux = 0;
-            int uy = panel_h;
+            string[] args = {};
+            if (_cursor_switch.active) args += "-c";
+            string geometry = "%d,%d %dx%d".printf(x, y, w, h);
+            args += "-g";
+            args += geometry;
+            run_local_screenshot(args, "Window captured and copied to clipboard", true);
+        }
 
-            int x, y, w, h;
-            switch (win.snap_type) {
-                case TilingLayout.SNAP_LEFT:         x=ux;       y=uy;       w=uw/2;  h=uh;   break;
-                case TilingLayout.SNAP_RIGHT:        x=ux+uw/2;  y=uy;       w=uw/2;  h=uh;   break;
-                case TilingLayout.SNAP_TOP_LEFT:     x=ux;       y=uy;       w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_TOP_RIGHT:    x=ux+uw/2;  y=uy;       w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_BOTTOM_LEFT:  x=ux;       y=uy+uh/2;  w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_BOTTOM_RIGHT: x=ux+uw/2;  y=uy+uh/2;  w=uw/2;  h=uh/2; break;
-                default: x=ux; y=uy; w=uw; h=uh; break;
-            }
-
+        private void run_local_screenshot(string[] capture_args, string notification_message,
+                                          bool fallback_to_monitor = false,
+                                          bool show_failure = true) {
             string temp_path;
             try {
                 int fd = GLib.FileUtils.open_tmp("singularity-screenshot-XXXXXX.png", out temp_path);
                 Posix.close(fd);
             } catch (Error e) {
                 warning("[ScreenshotTool] temp file: %s", e.message);
-                _do_fullscreen();
+                if (fallback_to_monitor) {
+                    _do_screen(false);
+                } else if (show_failure) {
+                    _show_unavailable_dialog();
+                }
                 return;
             }
-            string geometry = "%d,%d %dx%d".printf(x, y, w, h);
+
+            string helper = AppSystem.resolve_companion_bin("singularity-screenshot");
+            string[] argv = { helper };
+            foreach (var arg in capture_args) argv += arg;
+            argv += temp_path;
+
             try {
-                string[] argv = {"/usr/bin/grim", "-g", geometry, temp_path};
                 var proc = new GLib.Subprocess.newv(argv,
                     GLib.SubprocessFlags.STDOUT_SILENCE | GLib.SubprocessFlags.STDERR_SILENCE);
-                proc.wait_async.begin(null, (obj, res) => {
-                    try { proc.wait_async.end(res); } catch {}
-                    if (!GLib.FileUtils.test(temp_path, GLib.FileTest.EXISTS)) {
-                        _do_fullscreen();
+                proc.wait_check_async.begin(null, (obj, res) => {
+                    bool ok = false;
+                    try {
+                        ok = proc.wait_check_async.end(res);
+                    } catch (Error e) {
+                        warning("[ScreenshotTool] singularity-screenshot failed: %s", e.message);
+                    }
+                    if (!ok || !file_has_data(temp_path)) {
+                        GLib.FileUtils.unlink(temp_path);
+                        if (fallback_to_monitor) {
+                            _do_screen(false);
+                        } else if (show_failure) {
+                            _show_unavailable_dialog();
+                        }
                         return;
                     }
                     var portal = ScreenshotPortal.get_default();
                     portal.copy_to_clipboard(temp_path);
-                    portal.save_to_pictures("file://" + temp_path);
                     Singularity.Shell.ScreenFlash.flash();
-                    _notify_screenshot("Window captured and copied to clipboard", temp_path);
-                    GLib.Timeout.add(3000, () => { GLib.FileUtils.unlink(temp_path); return false; });
+                    _notify_screenshot(notification_message, temp_path);
+                    GLib.Timeout.add(3000, () => {
+                        GLib.FileUtils.unlink(temp_path);
+                        return GLib.Source.REMOVE;
+                    });
                 });
             } catch (Error e) {
-                warning("[ScreenshotTool] grim spawn failed: %s", e.message);
-                _do_fullscreen();
+                warning("[ScreenshotTool] singularity-screenshot spawn failed: %s", e.message);
+                GLib.FileUtils.unlink(temp_path);
+                if (fallback_to_monitor) {
+                    _do_screen(false);
+                } else if (show_failure) {
+                    _show_unavailable_dialog();
+                }
+            }
+        }
+
+        private string[]? target_monitor_capture_args() {
+            string[] args = {};
+            if (_cursor_switch.active) args += "-c";
+
+            if (_target_connector != null && _target_connector != "") {
+                args += "-o";
+                args += _target_connector;
+                return args;
+            }
+
+            if (_target_monitor != null) {
+                var geo = _target_monitor.get_geometry();
+                args += "-g";
+                args += "%d,%d %dx%d".printf(geo.x, geo.y, geo.width, geo.height);
+                return args;
+            }
+
+            return null;
+        }
+
+        private Gdk.Monitor? first_monitor() {
+            var display = Gdk.Display.get_default();
+            if (display == null) return null;
+            var monitors = display.get_monitors();
+            if (monitors.get_n_items() == 0) return null;
+            return monitors.get_item(0) as Gdk.Monitor;
+        }
+
+        private bool file_has_data(string path) {
+            try {
+                var info = File.new_for_path(path).query_info(
+                    "standard::size", FileQueryInfoFlags.NONE, null);
+                return info.get_size() > 0;
+            } catch (Error e) {
+                return false;
             }
         }
         private void setup_styles() {

--- a/src/core/shortcut_manager.vala
+++ b/src/core/shortcut_manager.vala
@@ -684,6 +684,10 @@ namespace Singularity {
         private void screenshot_tool_action() {
             var app = GLib.Application.get_default() as Gtk.Application;
             var tool = ScreenshotTool.get_default(app);
+            if (tool.visible) {
+                tool.close_dialog();
+                return;
+            }
             if (!tool.ensure_screenshots()) return;
             var handle = AppSystem.get_default().get_focused_window_handle();
             tool.prepare_for_invocation(handle);

--- a/src/core/shortcut_manager.vala
+++ b/src/core/shortcut_manager.vala
@@ -685,7 +685,8 @@ namespace Singularity {
             var app = GLib.Application.get_default() as Gtk.Application;
             var tool = ScreenshotTool.get_default(app);
             if (!tool.ensure_screenshots()) return;
-            tool.focused_handle = AppSystem.get_default().get_focused_window_handle();
+            var handle = AppSystem.get_default().get_focused_window_handle();
+            tool.prepare_for_invocation(handle);
             tool.open_dialog();
         }
 
@@ -707,42 +708,15 @@ namespace Singularity {
         }
 
         private void _screenshot_window(void* handle) {
-            // Use grim with the window's layout geometry for a pixel-perfect, unclipped screenshot.
-            // The snap_type tracked by TilingManager tells us which fraction of the screen this window
-            // occupies; combined with the monitor geometry we compute the exact crop rectangle.
             var app_system = AppSystem.get_default();
-            var win = app_system.get_window_by_handle(handle);
-            if (win == null || win.snap_type == 0) {
-                // Window not yet tiled or snap not recorded - fall back to fullscreen
+            int x, y, w, h, maximized, fullscreen;
+            string? connector;
+            bool got_geometry = Singularity.wayland_get_window_geometry(handle,
+                out x, out y, out w, out h, out maximized, out fullscreen, out connector);
+            if (!got_geometry || w <= 0 || h <= 0) {
+                warning("[Screenshot] no valid focused window geometry, falling back");
                 _screenshot_fullscreen();
                 return;
-            }
-            // Get monitor geometry
-            var monitors = Gdk.Display.get_default().get_monitors();
-            var monitor = monitors.get_item(0) as Gdk.Monitor;
-            if (monitor == null) { _screenshot_fullscreen(); return; }
-            var mon = monitor.get_geometry();
-            int mw = mon.width;
-            int mh = mon.height;
-
-            // Get usable area from AppSystem (updated at runtime by Panel and Dock)
-            int panel_h = app_system.shell_panel_height;
-            int dock_h = app_system.shell_dock_height;
-            int uw = mw;
-            int uh = mh - panel_h - dock_h;
-            int ux = 0;
-            int uy = panel_h;
-
-            // Map snap type to (x, y, w, h) within usable area
-            int x, y, w, h;
-            switch (win.snap_type) {
-                case TilingLayout.SNAP_LEFT:         x=ux;       y=uy;       w=uw/2;  h=uh;   break;
-                case TilingLayout.SNAP_RIGHT:        x=ux+uw/2;  y=uy;       w=uw/2;  h=uh;   break;
-                case TilingLayout.SNAP_TOP_LEFT:     x=ux;       y=uy;       w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_TOP_RIGHT:    x=ux+uw/2;  y=uy;       w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_BOTTOM_LEFT:  x=ux;       y=uy+uh/2;  w=uw/2;  h=uh/2; break;
-                case TilingLayout.SNAP_BOTTOM_RIGHT: x=ux+uw/2;  y=uy+uh/2;  w=uw/2;  h=uh/2; break;
-                default: /* SNAP_MAXIMIZE and unknown */ x=ux; y=uy; w=uw; h=uh; break;
             }
 
             string temp_path;
@@ -754,15 +728,21 @@ namespace Singularity {
                 return;
             }
             string geometry = "%d,%d %dx%d".printf(x, y, w, h);
-            message("[Screenshot] Using grim -g \"%s\", %s", geometry, temp_path);
+            message("[Screenshot] Using singularity-screenshot -g \"%s\", %s", geometry, temp_path);
             try {
-                string[] argv = {"/usr/bin/grim", "-g", geometry, temp_path};
+                string helper = AppSystem.resolve_companion_bin("singularity-screenshot");
+                string[] argv = { helper, "-g", geometry, temp_path };
                 var proc = new GLib.Subprocess.newv(argv,
                     GLib.SubprocessFlags.STDOUT_SILENCE | GLib.SubprocessFlags.STDERR_SILENCE);
-                proc.wait_async.begin(null, (obj, res) => {
-                    try { proc.wait_async.end(res); } catch {}
-                    if (!GLib.FileUtils.test(temp_path, GLib.FileTest.EXISTS)) {
-                        warning("[Screenshot] grim failed, falling back");
+                proc.wait_check_async.begin(null, (obj, res) => {
+                    bool ok = false;
+                    try {
+                        ok = proc.wait_check_async.end(res);
+                    } catch (Error e) {
+                        warning("[Screenshot] singularity-screenshot failed: %s", e.message);
+                    }
+                    if (!ok || !screenshot_file_has_data(temp_path)) {
+                        GLib.FileUtils.unlink(temp_path);
                         _screenshot_fullscreen();
                         return;
                     }
@@ -777,8 +757,19 @@ namespace Singularity {
                     GLib.Timeout.add(3000, () => { GLib.FileUtils.unlink(temp_path); return false; });
                 });
             } catch (Error e) {
-                warning("[Screenshot] grim spawn failed: %s", e.message);
+                warning("[Screenshot] singularity-screenshot spawn failed: %s", e.message);
+                GLib.FileUtils.unlink(temp_path);
                 _screenshot_fullscreen();
+            }
+        }
+
+        private bool screenshot_file_has_data(string path) {
+            try {
+                var info = File.new_for_path(path).query_info(
+                    "standard::size", FileQueryInfoFlags.NONE, null);
+                return info.get_size() > 0;
+            } catch (Error e) {
+                return false;
             }
         }
 

--- a/src/tools/screenshot/main.c
+++ b/src/tools/screenshot/main.c
@@ -50,15 +50,64 @@ typedef struct {
 typedef struct {
     State    *state;
     uint32_t  format, width, height, stride;
+    uint32_t  bytes_per_pixel;
     uint32_t  flags;
     int       fd;
     void     *data;
     size_t    size;
     struct wl_buffer *buffer;
     int  shm_received;
-    int  bgr_order;  /* 1 if format is XBGR/ABGR (bytes R,G,B,X - no swap needed) */
     int  done;   /* 1=ready, -1=failed, 0=pending */
 } Frame;
+
+static const char *shm_format_name(uint32_t fmt) {
+    switch (fmt) {
+    case WL_SHM_FORMAT_ARGB8888: return "ARGB8888";
+    case WL_SHM_FORMAT_XRGB8888: return "XRGB8888";
+    case WL_SHM_FORMAT_ABGR8888: return "ABGR8888";
+    case WL_SHM_FORMAT_XBGR8888: return "XBGR8888";
+    case WL_SHM_FORMAT_RGB888:   return "RGB888";
+    case WL_SHM_FORMAT_BGR888:   return "BGR888";
+    default: return "unsupported";
+    }
+}
+
+static int shm_format_info(uint32_t fmt, uint32_t *bytes_per_pixel) {
+    switch (fmt) {
+    case WL_SHM_FORMAT_ARGB8888:
+    case WL_SHM_FORMAT_XRGB8888:
+    case WL_SHM_FORMAT_ABGR8888:
+    case WL_SHM_FORMAT_XBGR8888:
+        if (bytes_per_pixel) *bytes_per_pixel = 4;
+        return 1;
+    case WL_SHM_FORMAT_RGB888:
+    case WL_SHM_FORMAT_BGR888:
+        if (bytes_per_pixel) *bytes_per_pixel = 3;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int shm_format_rank(uint32_t fmt) {
+    switch (fmt) {
+    case WL_SHM_FORMAT_XRGB8888:
+    case WL_SHM_FORMAT_ARGB8888:
+        return 30;
+    case WL_SHM_FORMAT_XBGR8888:
+    case WL_SHM_FORMAT_ABGR8888:
+        return 20;
+    case WL_SHM_FORMAT_BGR888:
+    case WL_SHM_FORMAT_RGB888:
+        return 10;
+    default:
+        return 0;
+    }
+}
+
+static int prefer_shm_format(uint32_t current, uint32_t candidate) {
+    return shm_format_rank(candidate) > shm_format_rank(current);
+}
 
 /* ── SHM buffer ───────────────────────────────────────────────────────────── */
 
@@ -93,17 +142,12 @@ static void frame_ev_buffer(void *data, struct zwlr_screencopy_frame_v1 *obj,
 {
     (void)obj;
     Frame *f = data;
-    /* Accept common 32bpp wl_shm and DRM fourcc formats.
-     * XR24=0x34325258 (XRGB, bytes B,G,R,X), XB24=0x34324258 (XBGR, bytes R,G,B,X),
-     * and their ARGB/ABGR variants. */
-    int is_bgr = (format == 0x34324258 || format == 0x34324241);
-    if (format == WL_SHM_FORMAT_ARGB8888 || format == WL_SHM_FORMAT_XRGB8888 ||
-        format == 0x34325241 || format == 0x34325258 ||
-        format == 0x34324241 || format == 0x34324258) {
+    uint32_t bytes_per_pixel = 0;
+    if (shm_format_info(format, &bytes_per_pixel)) {
         f->format = format;
         f->width = w; f->height = h; f->stride = stride;
+        f->bytes_per_pixel = bytes_per_pixel;
         f->shm_received = 1;
-        f->bgr_order = is_bgr;
     }
 }
 
@@ -169,11 +213,17 @@ static void ext_session_shm_format(void *data,
     struct ext_image_copy_capture_session_v1 *s, uint32_t format)
 {
     (void)s; Frame *f = ((ExtCtx *)data)->f;
-    if (format == WL_SHM_FORMAT_ARGB8888 || format == WL_SHM_FORMAT_XRGB8888)
+    uint32_t bytes_per_pixel = 0;
+    if (!shm_format_info(format, &bytes_per_pixel)) {
+        fprintf(stderr, "ignoring unsupported shm format %s (0x%x)\n",
+            shm_format_name(format), format);
+        return;
+    }
+    if (!f->shm_received || prefer_shm_format(f->format, format)) {
         f->format = format;
-    else if (!f->shm_received)
-        f->format = format;
-    f->shm_received = 1;
+        f->bytes_per_pixel = bytes_per_pixel;
+        f->shm_received = 1;
+    }
 }
 
 static void ext_session_dmabuf_device(void *data,
@@ -240,10 +290,9 @@ static int capture_output_ext(State *state, Output *out, int cursor, Frame *f) {
     while (!ctx.session_done && f->done == 0)
         if (wl_display_dispatch(state->display) < 0) goto out;
 
-    if (f->done == -1 || f->width == 0 || f->height == 0) goto out;
+    if (f->done == -1 || f->width == 0 || f->height == 0 || !f->shm_received) goto out;
 
-    f->stride = f->width * 4;
-    f->bgr_order = (f->format == 0x34324258 || f->format == 0x34324241);
+    f->stride = f->width * f->bytes_per_pixel;
     f->buffer = alloc_shm_buffer(f);
     if (!f->buffer) goto out;
 
@@ -394,12 +443,66 @@ static const struct wl_registry_listener registry_listener = {
 
 /* ── PNG write ────────────────────────────────────────────────────────────── */
 
-/* Write BGRA or RGBA pixel data as PNG.
- * For BGRA (ARGB8888 / XRGB8888 in LE memory), swap B↔R.
- * For RGBA (ABGR8888 / XBGR8888 in LE memory), bytes are already R,G,B,A - no swap.
- * Pass y_invert=1 when the ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT flag is set. */
-static int write_png_bgra(const char *path, const uint8_t *data,
-    uint32_t width, uint32_t height, uint32_t stride, int y_invert, int already_rgb)
+static void read_pixel_rgba(uint32_t format, const uint8_t *src, uint8_t *dst) {
+    switch (format) {
+    case WL_SHM_FORMAT_ARGB8888:
+    case WL_SHM_FORMAT_XRGB8888:
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+        break;
+    case WL_SHM_FORMAT_ABGR8888:
+    case WL_SHM_FORMAT_XBGR8888:
+        dst[0] = src[0];
+        dst[1] = src[1];
+        dst[2] = src[2];
+        break;
+    case WL_SHM_FORMAT_RGB888:
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+        break;
+    case WL_SHM_FORMAT_BGR888:
+        dst[0] = src[0];
+        dst[1] = src[1];
+        dst[2] = src[2];
+        break;
+    default:
+        dst[0] = dst[1] = dst[2] = 0;
+        break;
+    }
+    dst[3] = 0xff;
+}
+
+static int copy_frame_region_rgba(const Frame *frame,
+    uint32_t src_x, uint32_t src_y, uint32_t width, uint32_t height,
+    int y_invert, uint8_t *dst, uint32_t dst_stride)
+{
+    uint32_t bytes_per_pixel = 0;
+    if (!frame || !frame->data || !shm_format_info(frame->format, &bytes_per_pixel))
+        return -1;
+    if (frame->stride < frame->width * bytes_per_pixel)
+        return -1;
+    if (src_x > frame->width || src_y > frame->height ||
+        width > frame->width - src_x || height > frame->height - src_y)
+        return -1;
+    if (dst_stride < width * 4)
+        return -1;
+
+    const uint8_t *base = frame->data;
+    for (uint32_t y = 0; y < height; y++) {
+        uint32_t read_y = y_invert ? (frame->height - 1 - (src_y + y)) : (src_y + y);
+        const uint8_t *src = base + (size_t)read_y * frame->stride + (size_t)src_x * bytes_per_pixel;
+        uint8_t *out = dst + (size_t)y * dst_stride;
+        for (uint32_t x = 0; x < width; x++) {
+            read_pixel_rgba(frame->format, src + (size_t)x * bytes_per_pixel, out + (size_t)x * 4);
+        }
+    }
+    return 0;
+}
+
+static int write_png_rgba(const char *path, const uint8_t *data,
+    uint32_t width, uint32_t height, uint32_t stride)
 {
     FILE *fp = fopen(path, "wb");
     if (!fp) { perror(path); return -1; }
@@ -417,32 +520,26 @@ static int write_png_bgra(const char *path, const uint8_t *data,
         PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
     png_write_info(png, info);
 
-    uint8_t *row = malloc(stride);
-    if (!row) { png_destroy_write_struct(&png, &info); fclose(fp); return -1; }
-
     for (uint32_t y = 0; y < height; y++) {
-        uint32_t sy = y_invert ? (height - 1 - y) : y;
-        memcpy(row, data + (size_t)sy * stride, stride);
-        for (uint32_t x = 0; x < width; x++) {
-            if (!already_rgb) {
-                uint8_t b = row[x * 4];
-                row[x * 4]     = row[x * 4 + 2];
-                row[x * 4 + 2] = b;
-            }
-            /* Force opaque alpha. X-formats (XRGB/XBGR) leave the 4th byte
-             * undefined; some GPUs (e.g. NVIDIA) leave it 0, which made the
-             * whole screenshot transparent and render dark/washed out (#40).
-             * A screen capture is always opaque, so pin alpha to 255. */
-            row[x * 4 + 3] = 0xFF;
-        }
-        png_write_row(png, row);
+        png_write_row(png, data + (size_t)y * stride);
     }
-    free(row);
 
     png_write_end(png, NULL);
     png_destroy_write_struct(&png, &info);
     fclose(fp);
     return 0;
+}
+
+static int write_png_frame(const char *path, const Frame *frame, int y_invert) {
+    uint32_t stride = frame->width * 4;
+    uint8_t *rgba = malloc((size_t)stride * frame->height);
+    if (!rgba) return -1;
+    int rc = copy_frame_region_rgba(frame, 0, 0, frame->width, frame->height,
+        y_invert, rgba, stride);
+    if (rc == 0)
+        rc = write_png_rgba(path, rgba, frame->width, frame->height, stride);
+    free(rgba);
+    return rc;
 }
 
 /* ── Core capture ─────────────────────────────────────────────────────────── */
@@ -497,7 +594,7 @@ static int capture_output(State *state, Output *out, int cursor, const char *pat
     int rc = capture_one(state, out, cursor, &f);
     if (rc == 0) {
         int inv = (f.flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT) != 0;
-        rc = write_png_bgra(path, f.data, f.width, f.height, f.stride, inv, f.bgr_order);
+        rc = write_png_frame(path, &f, inv);
     } else {
         fprintf(stderr, "capture failed for output %s\n", out->name);
     }
@@ -535,7 +632,7 @@ static int capture_region(State *state,
         zwlr_screencopy_frame_v1_destroy(fo);
         if (rc == 0) {
             int inv = (f.flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT) != 0;
-            rc = write_png_bgra(path, f.data, f.width, f.height, f.stride, inv, f.bgr_order);
+            rc = write_png_frame(path, &f, inv);
             frame_cleanup(&f);
             return rc;
         }
@@ -567,12 +664,9 @@ static int capture_region(State *state,
     uint32_t cstride = pw * 4;
     uint8_t *crop = malloc((size_t)cstride * ph);
     if (!crop) { frame_cleanup(&ef); return -1; }
-    for (uint32_t row = 0; row < ph; row++) {
-        memcpy(crop + (size_t)row * cstride,
-               (const uint8_t *)ef.data + (size_t)(py + row) * ef.stride + (size_t)px * 4,
-               cstride);
-    }
-    int rc = write_png_bgra(path, crop, pw, ph, cstride, 0, ef.bgr_order);
+    int rc = copy_frame_region_rgba(&ef, (uint32_t)px, (uint32_t)py, pw, ph, 0, crop, cstride);
+    if (rc == 0)
+        rc = write_png_rgba(path, crop, pw, ph, cstride);
     free(crop);
     frame_cleanup(&ef);
     return rc;
@@ -623,17 +717,17 @@ static int capture_all(State *state, int cursor, const char *path) {
         int i = order[oi];
         Frame *f = &frames[i];
         int inv = (f->flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT) != 0;
-        for (uint32_t y = 0; y < f->height && y < total_h; y++) {
-            uint32_t sy = inv ? (f->height - 1 - y) : y;
-            memcpy(canvas + (size_t)y * canvas_stride + x_off * 4,
-                   (const uint8_t *)f->data + (size_t)sy * f->stride, f->width * 4);
+        if (copy_frame_region_rgba(f, 0, 0, f->width, f->height, inv,
+                canvas + (size_t)x_off * 4, canvas_stride) != 0) {
+            free(canvas);
+            for (int j = 0; j < n; j++)
+                frame_cleanup(&frames[j]);
+            return -1;
         }
         x_off += f->width;
     }
 
-    /* For multi-monitor canvas, swap bytes matching the first output's format */
-    int canvas_bgr = (n > 0) ? frames[0].bgr_order : 0;
-    int rc = write_png_bgra(path, canvas, total_w, total_h, canvas_stride, 0, canvas_bgr);
+    int rc = write_png_rgba(path, canvas, total_w, total_h, canvas_stride);
     free(canvas);
     for (int i = 0; i < n; i++)
         frame_cleanup(&frames[i]);


### PR DESCRIPTION
This PR fixes Singularity screenshot capture in two layers: the low-level singularity-screenshot helper and the shell screenshot UI behavior.

The helper now correctly handles compositor-advertised shm formats, including 24-bit RGB888/BGR888, and no longer assumes every capture buffer is 4 bytes per pixel. This fixes the observed installed-session failure where the compositor advertised BGR888, but the helper allocated a width * 4 stride and wlroots rejected it with  "Invalid stride (10240)".

The screenshot UI now captures the intended target instead of always falling back to all displays. Screen mode captures the monitor where the UI was summoned, based on the previously focused window’s monitor. Window mode captures the previously focused window using compositor-provided window geometry. The old _/usr/bin/grim_ path and snap_type-based geometry approximation were removed for these paths.

Big Changes

- Added format-aware shm handling in singularity-screenshot.
- Added support for ARGB8888, XRGB8888, ABGR8888, XBGR8888, RGB888, and BGR888.
- Changed screenshot buffer stride calculation to use the selected format’s bytes-per-pixel.
- Replaced direct PNG writes from source buffers with conversion into RGBA rows.
- Updated multi-output and crop paths to composite/crop from format-aware RGBA data.
- Added screenshot UI invocation targeting via ScreenshotTool.prepare_for_invocation().
- Pinned the screenshot tool UI to the monitor associated with the previously focused window.
- Changed UI Screen mode to call singularity-screenshot -o <connector> or fallback to monitor geometry.
- Changed UI Window mode to call wayland_get_window_geometry() and capture with singularity-screenshot -g.
- Removed UI and Alt+Print dependency on hardcoded /usr/bin/grim.
- Removed snap_type dependency for window screenshots.
- Updated Alt+Print window capture to use the same compositor geometry approach.
- Ran nix flake update before nix build, updating flake.lock.

Tested on: NixOS 26.05