### PR TITLE
fix: avoid screenshot show-in-files crash

### DIFF
--- a/src/core/screenshot_tool.vala
+++ b/src/core/screenshot_tool.vala
@@ -389,23 +389,35 @@ namespace Singularity {
             } else if (action == "show") {
                 try {
                     var file = File.new_for_path(path);
-                    var parent = file.get_parent();
-                    if (parent != null)
-                        AppInfo.launch_default_for_uri(parent.get_uri(), null);
-                    try {
-                        var bus = Bus.get_sync(BusType.SESSION);
-                        bus.call_sync("org.freedesktop.FileManager1",
-                            "/org/freedesktop/FileManager1",
-                            "org.freedesktop.FileManager1",
-                            "ShowItems",
-                            new Variant("(ass)", new string[]{file.get_uri()}, ""),
-                            null, DBusCallFlags.NONE, -1, null);
-                    } catch {}
+                    if (!_show_item_in_files(file)) {
+                        var parent = file.get_parent();
+                        if (parent != null)
+                            AppInfo.launch_default_for_uri(parent.get_uri(), null);
+                    }
                 } catch (Error e) {
                     warning("[ScreenshotTool] Failed to show in files: %s", e.message);
                 }
             }
             _screenshot_notification_actions.remove(id);
+        }
+
+        private bool _show_item_in_files(File file) {
+            try {
+                var uris = new VariantBuilder(new VariantType("as"));
+                uris.add("s", file.get_uri());
+
+                var bus = Bus.get_sync(BusType.SESSION);
+                bus.call_sync("org.freedesktop.FileManager1",
+                    "/org/freedesktop/FileManager1",
+                    "org.freedesktop.FileManager1",
+                    "ShowItems",
+                    new Variant("(ass)", uris, ""),
+                    null, DBusCallFlags.NONE, -1, null);
+                return true;
+            } catch (Error e) {
+                warning("[ScreenshotTool] Failed to reveal screenshot in files: %s", e.message);
+                return false;
+            }
         }
 
         private void dispatch_capture() {


### PR DESCRIPTION
Fixes a crash when clicking `Show in Files` on the screenshot completion notification.

The screenshot was saved successfully and the Files app could open, but doing so meant the desktop would crash immediately afterward while trying to call `org.freedesktop.FileManager1.ShowItems`.

The logs showed a fatal GLib variant construction failure:

```text
g_variant_builder_end: assertion 'valid_builder' failed
g_variant_new: expected array GVariantBuilder but the built value has type '(null)'

what was changed'
created a VariantBuilder for the as URI array
added the screenshot URI with uris.add("s", file.get_uri())
calls org.freedesktop.FileManager1.ShowItems using new Variant("(ass)", uris, "")
falls back to opening the parent directory if ShowItems is unavailable or fails

tested on: NixOS 26.05 and Ubuntu 26.04