### PR TITLE
Enhancement: Resolve Steam Proton game desktop entries in shell and keep steam games as their own listing separate from steam

### DIFF
--- a/src/components/dock/dock.vala
+++ b/src/components/dock/dock.vala
@@ -1718,12 +1718,12 @@ namespace Singularity {
             if (an == bn) return true;
             if (an.has_suffix("." + bn) || bn.has_suffix("." + an)) return true;
             // StartupWMClass - the standard desktop-entry way
-            var dinfo_a = app_system.get_app_info(id_a) as GLib.DesktopAppInfo;
+            var dinfo_a = app_system.resolve_app_for_id(id_a) as GLib.DesktopAppInfo;
             if (dinfo_a != null) {
                 string? wm = dinfo_a.get_startup_wm_class();
                 if (wm != null && wm.down() == b) return true;
             }
-            var dinfo_b = app_system.get_app_info(id_b) as GLib.DesktopAppInfo;
+            var dinfo_b = app_system.resolve_app_for_id(id_b) as GLib.DesktopAppInfo;
             if (dinfo_b != null) {
                 string? wm = dinfo_b.get_startup_wm_class();
                 if (wm != null && wm.down() == a) return true;

--- a/src/components/panel/panel.vala
+++ b/src/components/panel/panel.vala
@@ -175,7 +175,7 @@ namespace Singularity {
                         app_title_label.label = "";
                         return;
                     }
-                    var app_info = app_system.get_app_info(app_id);
+                    var app_info = app_system.resolve_app_for_id(app_id);
                     if (app_info != null) {
                         app_title_label.label = app_info.get_name();
                     } else {

--- a/src/core/app_system.vala
+++ b/src/core/app_system.vala
@@ -8,6 +8,7 @@ namespace Singularity {
         private static AppSystem? _instance = null;
         private GLib.Settings settings;
         private HashTable<string, AppInfo> installed_apps_map;
+        private HashTable<string, AppInfo> steam_app_map;
         private List<AppInfo> installed_apps_list;
         // Keeps the GLib.AppInfo objects alive - AppInfo is a Vala interface so
         // neither HashTable nor List generates g_object_ref/unref for it automatically.
@@ -147,6 +148,7 @@ namespace Singularity {
 
         private AppSystem() {
             installed_apps_map = new HashTable<string, AppInfo>(str_hash, str_equal);
+            steam_app_map = new HashTable<string, AppInfo>(str_hash, str_equal);
             installed_apps_list = new List<AppInfo>();
             running_apps_list = new List<string>();
             workspaces = new List<Workspace>();
@@ -1005,6 +1007,78 @@ namespace Singularity {
             return null;
         }
 
+        private static bool is_digit_char(char c) {
+            return c >= '0' && c <= '9';
+        }
+
+        private static string? extract_digits_after(string text, string marker) {
+            int pos = text.index_of(marker);
+            if (pos < 0) return null;
+
+            int start = pos + marker.length;
+            if (start >= text.length || !is_digit_char(text[start])) return null;
+
+            int end = start;
+            while (end < text.length && is_digit_char(text[end])) end++;
+
+            return text[start:end];
+        }
+
+        private static string? extract_steam_appid_from_text(string? text) {
+            if (text == null || text == "") return null;
+
+            string lower = text.down();
+            string? appid = extract_digits_after(lower, "steam://rungameid/");
+            if (appid != null) return appid;
+
+            appid = extract_digits_after(lower, "steam://run/");
+            if (appid != null) return appid;
+
+            return extract_digits_after(lower, "steam_app_");
+        }
+
+        private static string? steam_runtime_id_from_app_id(string app_id) {
+            if (app_id == null || app_id == "") return null;
+
+            string lower = app_id.down();
+            if (lower.has_suffix(".desktop")) {
+                lower = lower[0:lower.length - 8];
+            }
+
+            if (!lower.has_prefix("steam_app_")) return null;
+            int start = "steam_app_".length;
+            if (start >= lower.length) return null;
+
+            for (int i = start; i < lower.length; i++) {
+                if (!is_digit_char(lower[i])) return null;
+            }
+
+            return lower;
+        }
+
+        private void index_steam_app(AppInfo app) {
+            var dapp = app as GLib.DesktopAppInfo;
+            if (dapp == null) return;
+
+            string? appid = extract_steam_appid_from_text(dapp.get_startup_wm_class());
+            if (appid == null) appid = extract_steam_appid_from_text(dapp.get_string("Exec"));
+            if (appid == null) appid = extract_steam_appid_from_text(app.get_id());
+            if (appid == null) appid = extract_steam_appid_from_text(dapp.get_filename());
+            if (appid == null) return;
+
+            string runtime_id = "steam_app_" + appid;
+            if (!steam_app_map.contains(runtime_id)) {
+                steam_app_map.insert(runtime_id, app);
+            }
+        }
+
+        private AppInfo? resolve_steam_app_for_id(string app_id) {
+            string? runtime_id = steam_runtime_id_from_app_id(app_id);
+            if (runtime_id == null) return null;
+            if (!steam_app_map.contains(runtime_id)) return null;
+            return steam_app_map.get(runtime_id);
+        }
+
         // Resolve an app_id to its installed AppInfo, trying progressively looser
         // matches. Shared by initial window resolution and the post-scan re-resolve.
         public AppInfo? resolve_app_for_id(string app_id) {
@@ -1015,21 +1089,27 @@ namespace Singularity {
             }
             if (app_info == null) {
                 foreach (var app in installed_apps_list) {
-                    string? raw_id = app.get_id();
-                    if (raw_id == null) continue;
-                    string id = raw_id.down();
-                    if (id.contains(icon_name) || icon_name.contains(id)) {
+                    var dapp = app as GLib.DesktopAppInfo;
+                    if (dapp == null) continue;
+                    string? wm = dapp.get_startup_wm_class();
+                    if (wm != null && wm.down() == icon_name) {
                         app_info = app;
                         break;
                     }
                 }
             }
             if (app_info == null) {
+                app_info = resolve_steam_app_for_id(app_id);
+            }
+            if (app_info == null && steam_runtime_id_from_app_id(app_id) != null) {
+                return null;
+            }
+            if (app_info == null) {
                 foreach (var app in installed_apps_list) {
-                    var dapp = app as GLib.DesktopAppInfo;
-                    if (dapp == null) continue;
-                    string? wm = dapp.get_startup_wm_class();
-                    if (wm != null && wm.down() == icon_name) {
+                    string? raw_id = app.get_id();
+                    if (raw_id == null) continue;
+                    string id = raw_id.down();
+                    if (id.contains(icon_name) || icon_name.contains(id)) {
                         app_info = app;
                         break;
                     }
@@ -1068,12 +1148,30 @@ namespace Singularity {
         // gicon. The dock re-resolves on refresh, but the overview/alt-tab read
         // win.gicon directly, so re-resolve them once the app list is ready.
         private void reresolve_window_icons() {
+            bool running_ids_changed = false;
             foreach (var win in windows) {
-                if (win.gicon != null) continue;
+                if (win.gicon != null && steam_runtime_id_from_app_id(win.app_id) == null) continue;
                 var app_info = resolve_app_for_id(win.app_id);
                 if (app_info == null) continue;
+                string old_app_id = win.app_id;
                 win.gicon = app_info.get_icon();
                 win.icon_name = icon_name_for(app_info, win.icon_name);
+                string? canonical_id = app_info.get_id();
+                if (canonical_id != null && canonical_id != "" && canonical_id != win.app_id) {
+                    win.app_id = canonical_id.dup();
+                    running_ids_changed = true;
+
+                    unowned List<string> old_running = running_apps_list.find_custom(old_app_id, strcmp);
+                    if (old_running != null) {
+                        running_apps_list.remove(old_running.data);
+                    }
+                    if (running_apps_list.find_custom(win.app_id, strcmp) == null) {
+                        running_apps_list.append(win.app_id.dup());
+                    }
+                }
+            }
+            if (running_ids_changed) {
+                schedule_running_apps_changed();
             }
         }
 
@@ -1296,12 +1394,14 @@ namespace Singularity {
             // Update owner FIRST so new objects are alive before old ones are released
             _app_info_owner = AppInfo.get_all();
             installed_apps_map.remove_all();
+            steam_app_map.remove_all();
             installed_apps_list = new List<AppInfo>();
             foreach (var app in _app_info_owner) {
                 string id = app.get_id();
                 if (id != null) {
                     installed_apps_map.insert(id, app);
                     installed_apps_list.append(app);
+                    index_steam_app(app);
                 }
             }
             scan_desktop_app_dirs();
@@ -1344,6 +1444,7 @@ namespace Singularity {
                         _app_info_owner.append(app);
                         installed_apps_map.insert(id, app);
                         installed_apps_list.append(app);
+                        index_steam_app(app);
                     }
                 } catch (Error e) {
                     // Missing or unreadable application dirs are normal for optional prefixes.

--- a/src/core/main.vala
+++ b/src/core/main.vala
@@ -1053,9 +1053,7 @@ window.inactive.shadow.color: %s
 
     public void open_app_settings(string app_id) throws IOError {
         Idle.add(() => {
-            var app_info = Singularity.AppSystem.get_default().get_app_info(app_id);
-            if (app_info == null)
-                app_info = Singularity.AppSystem.get_default().get_app_info(app_id + ".desktop");
+            var app_info = Singularity.AppSystem.get_default().resolve_app_for_id(app_id);
             if (app_info != null) {
                 open_app_details(app_info);
             } else {

--- a/src/core/screenshot_tool.vala
+++ b/src/core/screenshot_tool.vala
@@ -389,23 +389,35 @@ namespace Singularity {
             } else if (action == "show") {
                 try {
                     var file = File.new_for_path(path);
-                    var parent = file.get_parent();
-                    if (parent != null)
-                        AppInfo.launch_default_for_uri(parent.get_uri(), null);
-                    try {
-                        var bus = Bus.get_sync(BusType.SESSION);
-                        bus.call_sync("org.freedesktop.FileManager1",
-                            "/org/freedesktop/FileManager1",
-                            "org.freedesktop.FileManager1",
-                            "ShowItems",
-                            new Variant("(ass)", new string[]{file.get_uri()}, ""),
-                            null, DBusCallFlags.NONE, -1, null);
-                    } catch {}
+                    if (!_show_item_in_files(file)) {
+                        var parent = file.get_parent();
+                        if (parent != null)
+                            AppInfo.launch_default_for_uri(parent.get_uri(), null);
+                    }
                 } catch (Error e) {
                     warning("[ScreenshotTool] Failed to show in files: %s", e.message);
                 }
             }
             _screenshot_notification_actions.remove(id);
+        }
+
+        private bool _show_item_in_files(File file) {
+            try {
+                var uris = new VariantBuilder(new VariantType("as"));
+                uris.add("s", file.get_uri());
+
+                var bus = Bus.get_sync(BusType.SESSION);
+                bus.call_sync("org.freedesktop.FileManager1",
+                    "/org/freedesktop/FileManager1",
+                    "org.freedesktop.FileManager1",
+                    "ShowItems",
+                    new Variant("(ass)", uris, ""),
+                    null, DBusCallFlags.NONE, -1, null);
+                return true;
+            } catch (Error e) {
+                warning("[ScreenshotTool] Failed to reveal screenshot in files: %s", e.message);
+                return false;
+            }
         }
 
         private void dispatch_capture() {


### PR DESCRIPTION
Changed Files

app_system.vala:
- Added steam_app_map to index Steam game desktop entries by runtime IDs like steam_app_570.
- Added parsers for steam://rungameid/<appid>, steam://run/<appid>, and steam_app_<appid>.
- Indexed Steam entries during both AppInfo.get_all() scanning and manual XDG application-dir scanning.
- Reordered resolve_app_for_id() so exact IDs and StartupWMClass are tried first, then Steam runtime mapping, then the older fuzzy fallbacks.
- Added a guard so unresolved steam_app_<appid> windows do not fall through to the old prefix match that could incorrectly resolve them as Steam.
- Updated reresolve_window_icons() so Steam windows opened before app scanning can later be canonicalized to the game desktop entry and refresh running-app state.

dock.vala:
- Updated dock matching to use app_system.resolve_app_for_id() instead of direct get_app_info() lookups for StartupWMClass matching.
- This keeps Steam-specific mapping centralized in AppSystem.

panel.vala:
Updated focused app label resolution to use the shared resolver, so mapped Proton games can show their game name instead of steam_app_<appid> or Steam.

main.vala:
Updated app-settings lookup to use resolve_app_for_id() for consistency with dock and panel behavior.

Tested on: NixOS 26.05 and Ubuntu 26.04