### PR TITLE
fix: complete Batch 1 fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ singularity_core_sources = files(
     'src/core/dbus_menu_adapter.vala',
     'src/core/atspi_menu_provider.vala',
     'src/core/gtk_actions_menu_provider.vala',
+    'src/core/xdg_user_dirs.vala',
     'src/core/app_system.vala',
     'src/core/os_identity.vala',
     'src/core/compositor_backend.vala',

--- a/src/components/desktop/desktop_icons.vala
+++ b/src/components/desktop/desktop_icons.vala
@@ -7,7 +7,7 @@ namespace Singularity {
         private GLib.Settings settings;
         private Fixed icon_container;
         private FileMonitor? monitor;
-        private string desktop_path;
+        private string? desktop_path;
         private HashTable<string, IconPosition?> icon_positions;
         private string positions_file;
         private HashTable<string, Gdk.Pixbuf> _icon_pixbuf_cache;
@@ -35,7 +35,7 @@ namespace Singularity {
         public DesktopIcons(Gtk.Application app, Gdk.Monitor? monitor = null) {
             Object(application: app);
             settings = new GLib.Settings("dev.sinty.desktop");
-            desktop_path = Environment.get_home_dir() + "/Desktop";
+            desktop_path = XdgUserDirs.desktop_dir();
             positions_file = Environment.get_home_dir() + "/.config/singularity/desktop-icons.txt";
             icon_positions = new HashTable<string, IconPosition?>(str_hash, str_equal);
             _icon_pixbuf_cache = new HashTable<string, Gdk.Pixbuf>(str_hash, str_equal);
@@ -249,8 +249,10 @@ namespace Singularity {
         }
 
         private void setup_file_monitor() {
+            string? path = desktop_path;
+            if (path == null) return;
             try {
-                var desktop = File.new_for_path(desktop_path);
+                var desktop = File.new_for_path(path);
                 if (!desktop.query_exists()) {
                     desktop.make_directory_with_parents();
                 }
@@ -288,8 +290,10 @@ namespace Singularity {
                 icon_container.remove(child);
                 child = next;
             }
+            string? path = desktop_path;
+            if (path == null) return;
             try {
-                var desktop = File.new_for_path(desktop_path);
+                var desktop = File.new_for_path(path);
                 if (!desktop.query_exists()) return;
                 var enumerator = desktop.enumerate_children("standard::*,time::modified", FileQueryInfoFlags.NONE);
                 // Rebuild placement from scratch onto the shared lattice so any
@@ -345,8 +349,10 @@ namespace Singularity {
         // and re-decodes every icon on each event, which is the hot path).
         private void update_single_icon(string name) {
             if (name.has_prefix(".")) return;
+            string? path = desktop_path;
+            if (path == null) return;
             try {
-                var desktop = File.new_for_path(desktop_path);
+                var desktop = File.new_for_path(path);
                 var file = desktop.get_child(name);
                 if (!file.query_exists()) { remove_single_icon(name); return; }
                 var info = file.query_info("standard::*,time::modified", FileQueryInfoFlags.NONE);
@@ -662,9 +668,11 @@ namespace Singularity {
         }
 
         private void sort_icons_by_type() {
+            string? path = desktop_path;
+            if (path == null) return;
             var files = new GLib.List<FileEntry>();
             try {
-                var desktop = File.new_for_path(desktop_path);
+                var desktop = File.new_for_path(path);
                 var enumerator = desktop.enumerate_children("standard::*", FileQueryInfoFlags.NONE);
                 FileInfo? info;
                 while ((info = enumerator.next_file()) != null) {

--- a/src/components/overview/app_folder_overlay.vala
+++ b/src/components/overview/app_folder_overlay.vala
@@ -34,6 +34,7 @@ namespace Singularity {
             GtkLayerShell.set_exclusive_zone(this, -1);
             decorated = false;
             add_css_class("folder-overlay-window");
+            add_css_class("folder-overlay-dimmer");
             add_css_class("singularity");
 
             // Dim background - close only when the press lands outside the card.
@@ -250,6 +251,7 @@ namespace Singularity {
             opacity = 0;
             visible = true;
             present();
+            Singularity.request_surface_blur(this, 28);
             // Remove auto-focus from entry (GTK4 focuses first focusable widget on present)
             set_focus(null);
             name_entry.focusable = false;

--- a/src/components/sidebar/pages/desktop_page.vala
+++ b/src/components/sidebar/pages/desktop_page.vala
@@ -840,7 +840,7 @@ namespace Singularity {
             add_group(launcher_group);
 
             var desktop_group = new PreferencesGroup(_("Desktop Icons"));
-            var icons_row = new SwitchRow(_("Show Desktop Icons"), _("Display files from ~/Desktop on screen"), settings.get_boolean("show-desktop-icons"));
+            var icons_row = new SwitchRow(_("Show Desktop Icons"), _("Display files from your desktop folder on screen"), settings.get_boolean("show-desktop-icons"));
             icons_row.switch_btn.notify["active"].connect(() => {
                 settings.set_boolean("show-desktop-icons", icons_row.switch_btn.active);
             });

--- a/src/core/app_system.vala
+++ b/src/core/app_system.vala
@@ -343,8 +343,8 @@ namespace Singularity {
             var entry = app as DesktopAppInfo;
             string? src = (entry != null) ? entry.get_filename() : null;
             if (src == null) return false;
-            string desktop_dir = Environment.get_user_special_dir(UserDirectory.DESKTOP)
-                ?? Path.build_filename(Environment.get_home_dir(), "Desktop");
+            string? desktop_dir = XdgUserDirs.desktop_dir();
+            if (desktop_dir == null) return false;
             try {
                 var dir = File.new_for_path(desktop_dir);
                 if (!dir.query_exists()) dir.make_directory_with_parents();

--- a/src/core/xdg_user_dirs.vala
+++ b/src/core/xdg_user_dirs.vala
@@ -1,0 +1,24 @@
+using GLib;
+
+namespace Singularity {
+
+    public class XdgUserDirs : Object {
+        private XdgUserDirs() {}
+
+        public static string? desktop_dir() {
+            string? configured = Environment.get_user_special_dir(UserDirectory.DESKTOP);
+            string dir;
+            if (configured != null && configured.strip() != "") {
+                dir = configured;
+            } else {
+                dir = Path.build_filename(Environment.get_home_dir(), "Desktop");
+            }
+
+            if (File.new_for_path(dir).equal(File.new_for_path(Environment.get_home_dir()))) {
+                return null;
+            }
+
+            return dir;
+        }
+    }
+}

--- a/src/wayland/blur_surface.c
+++ b/src/wayland/blur_surface.c
@@ -30,6 +30,22 @@
 /* Per-display cache of the blur manager proxy */
 static struct zsingularity_blur_manager_v1 *cached_blur_manager = NULL;
 static struct wl_display *cached_wl_display = NULL;
+static const char *blur_data_key = "singularity-surface-blur";
+static const char *blur_signal_key = "singularity-surface-blur-signal";
+
+static void
+destroy_surface_blur(GtkWidget *widget, gpointer user_data)
+{
+	(void)user_data;
+	struct zsingularity_blur_v1 *blur =
+		g_object_get_data(G_OBJECT(widget), blur_data_key);
+	if (!blur) {
+		return;
+	}
+
+	zsingularity_blur_v1_destroy(blur);
+	g_object_set_data(G_OBJECT(widget), blur_data_key, NULL);
+}
 
 static void
 registry_global(void *data, struct wl_registry *registry, uint32_t name,
@@ -111,11 +127,20 @@ singularity_request_surface_blur(GtkWidget *widget, uint32_t radius)
 	}
 
 	struct zsingularity_blur_v1 *blur =
-		zsingularity_blur_manager_v1_get_blur(manager, wl_surface);
+		g_object_get_data(G_OBJECT(widget), blur_data_key);
+	if (!blur) {
+		blur = zsingularity_blur_manager_v1_get_blur(manager, wl_surface);
+		g_object_set_data(G_OBJECT(widget), blur_data_key, blur);
+		if (!g_object_get_data(G_OBJECT(widget), blur_signal_key)) {
+			g_signal_connect(widget, "unrealize",
+				G_CALLBACK(destroy_surface_blur), NULL);
+			g_object_set_data(G_OBJECT(widget), blur_signal_key,
+				GINT_TO_POINTER(1));
+		}
+	}
 	zsingularity_blur_v1_set_radius(blur, radius);
 	zsingularity_blur_v1_set_noise(blur, 0);
 	zsingularity_blur_v1_commit(blur);
-	/* Keep blur object alive for the lifetime of the surface */
 
 #else
 	(void)widget;


### PR DESCRIPTION
Uses the configured XDG Desktop directory and makes app folder overlays translucent with compositor blur.

Meta issues: singularityos-lab/singularity-desktop#53, singularityos-lab/singularity-desktop#226

Checked with the integrated Meson build, test suite, XDG harness, and a nested labwc visual run.