### PR TITLE
shell: drop the GdkSurface when a layer-shell window closes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -324,6 +324,7 @@ singularity_core_sources = files(
     'src/components/sidebar/pages/performance_page.vala',
     'src/core/display_manager.vala',
     'src/core/hot_corner_manager.vala',
+    'src/core/layer_window.vala',
     'src/core/monitor_osd.vala',
     'src/core/system_components.vala',
     'src/core/debug_manager.vala',

--- a/src/components/dock/dock.vala
+++ b/src/components/dock/dock.vala
@@ -241,11 +241,7 @@ namespace Singularity {
                 }
                 if (key == "panel-fusion") {
                     update_fusion();
-                    ((Gtk.Widget) this).hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     update_visibility_mode();
                     pulse_frame_clock();
                 }
@@ -261,11 +257,7 @@ namespace Singularity {
                 if (key == "dock-enabled") {
                     _enabled = _settings.get_boolean("dock-enabled");
                     if (!_enabled) {
-                        ((Gtk.Widget) this).hide();
-                        // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                        // Cast required: GtkWindow implements GtkNative, so a bare
-                        // unrealize() binds to gtk_native_unrealize, not the widget one.
-                        ((Gtk.Widget) this).unrealize();
+                        close_layer_window (this);
                         set_exclusive_zone(this, 0);
                         app_system.shell_dock_height = 0;
                         _set_reveal_barrier_active(false);
@@ -935,11 +927,7 @@ namespace Singularity {
                     queue_draw();
                     break;
                 case "remap":
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     present();
                     queue_draw();
                     break;
@@ -1048,11 +1036,7 @@ namespace Singularity {
                 // is live right after the remap (and we pulse it), so the content
                 // transform is presented reliably without moving the surface.
                 set_body_class("dock-reveal-offset", true);
-                ((Gtk.Widget) this).hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
                 present();
                 start_content_slide();
             }
@@ -1156,11 +1140,7 @@ namespace Singularity {
                 return;
             }
             if (!_enabled) {
-                ((Gtk.Widget) this).hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
                 set_exclusive_zone(this, 0);
                 app_system.shell_dock_height = 0;
                 _set_reveal_barrier_active(false);
@@ -1177,11 +1157,7 @@ namespace Singularity {
                 // Re-trigger size_allocate to restore the correct exclusive zone
                 queue_resize();
             } else if (visibility_mode == "overview-only") {
-                hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
                 set_exclusive_zone(this, 0);
             }
             update_autohide_state();
@@ -1231,11 +1207,7 @@ namespace Singularity {
                 // window covering it) is not composited until a frame is
                 // committed, so closing a focused fullscreen window left the
                 // dock buried. Remap to force a fresh buffer and present.
-                ((Gtk.Widget) this).hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
                 present();
                 update_visibility_mode();
                 pulse_frame_clock();

--- a/src/components/dock/dock.vala
+++ b/src/components/dock/dock.vala
@@ -975,9 +975,13 @@ namespace Singularity {
             var fc = get_frame_clock();
             if (fc == null) return;
             fc.begin_updating();
+            // End the clock we began, not whatever get_frame_clock() returns
+            // 350ms later: closing a layer window now drops the GdkSurface, so
+            // the next present allocates a NEW frame clock. Re-fetching here
+            // would leave the original permanently updating and double-end the
+            // new one on a quick pointer leave/re-enter.
             GLib.Timeout.add(350, () => {
-                var f = get_frame_clock();
-                if (f != null) f.end_updating();
+                fc.end_updating();
                 return GLib.Source.REMOVE;
             });
         }

--- a/src/components/dock/dock.vala
+++ b/src/components/dock/dock.vala
@@ -242,6 +242,10 @@ namespace Singularity {
                 if (key == "panel-fusion") {
                     update_fusion();
                     ((Gtk.Widget) this).hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     update_visibility_mode();
                     pulse_frame_clock();
                 }
@@ -258,6 +262,10 @@ namespace Singularity {
                     _enabled = _settings.get_boolean("dock-enabled");
                     if (!_enabled) {
                         ((Gtk.Widget) this).hide();
+                        // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                        // Cast required: GtkWindow implements GtkNative, so a bare
+                        // unrealize() binds to gtk_native_unrealize, not the widget one.
+                        ((Gtk.Widget) this).unrealize();
                         set_exclusive_zone(this, 0);
                         app_system.shell_dock_height = 0;
                         _set_reveal_barrier_active(false);
@@ -928,6 +936,10 @@ namespace Singularity {
                     break;
                 case "remap":
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     present();
                     queue_draw();
                     break;
@@ -1037,6 +1049,10 @@ namespace Singularity {
                 // transform is presented reliably without moving the surface.
                 set_body_class("dock-reveal-offset", true);
                 ((Gtk.Widget) this).hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
                 present();
                 start_content_slide();
             }
@@ -1141,6 +1157,10 @@ namespace Singularity {
             }
             if (!_enabled) {
                 ((Gtk.Widget) this).hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
                 set_exclusive_zone(this, 0);
                 app_system.shell_dock_height = 0;
                 _set_reveal_barrier_active(false);
@@ -1158,6 +1178,10 @@ namespace Singularity {
                 queue_resize();
             } else if (visibility_mode == "overview-only") {
                 hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
                 set_exclusive_zone(this, 0);
             }
             update_autohide_state();
@@ -1208,6 +1232,10 @@ namespace Singularity {
                 // committed, so closing a focused fullscreen window left the
                 // dock buried. Remap to force a fresh buffer and present.
                 ((Gtk.Widget) this).hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
                 present();
                 update_visibility_mode();
                 pulse_frame_clock();

--- a/src/components/overview/app_menu.vala
+++ b/src/components/overview/app_menu.vala
@@ -158,11 +158,7 @@ namespace Singularity {
             });
             ((Gtk.Widget)this).add_controller(key_controller);
 
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
         }
 
         private void apply_monitor_sizing() {
@@ -273,11 +269,7 @@ namespace Singularity {
                 menu_animation.tick.connect(() => { opacity = menu_animation.value; });
                 menu_animation.done.connect(() => {
                     if (_is_open) return;
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 });
@@ -341,11 +333,7 @@ namespace Singularity {
                 opacity = target;
                 if (stay_open) search_entry.grab_focus();
                 else {
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 }
@@ -365,11 +353,7 @@ namespace Singularity {
                 if (menu_animation == animation) menu_animation = null;
                 if (stay_open) search_entry.grab_focus();
                 else {
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 }

--- a/src/components/overview/app_menu.vala
+++ b/src/components/overview/app_menu.vala
@@ -159,6 +159,10 @@ namespace Singularity {
             ((Gtk.Widget)this).add_controller(key_controller);
 
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
         }
 
         private void apply_monitor_sizing() {
@@ -270,6 +274,10 @@ namespace Singularity {
                 menu_animation.done.connect(() => {
                     if (_is_open) return;
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 });
@@ -334,6 +342,10 @@ namespace Singularity {
                 if (stay_open) search_entry.grab_focus();
                 else {
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 }
@@ -354,6 +366,10 @@ namespace Singularity {
                 if (stay_open) search_entry.grab_focus();
                 else {
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     if (widgets_grid != null) widgets_grid.depopulate();
                     hidden();
                 }

--- a/src/components/overview/overview.vala
+++ b/src/components/overview/overview.vala
@@ -334,6 +334,22 @@ namespace Singularity {
                     _anim_out_timer = 0;
                     main_box.remove_css_class("animating-out");
                     hide();
+                    // Drop the GdkSurface, do not merely unmap it.
+                    // GTK reuses one wl_surface across hide/show, and
+                    // gtk4-layer-shell builds a fresh layer surface over
+                    // it on the next open. A frame queued by the closing
+                    // animation can land after the unmap and re-attach a
+                    // live buffer; the next open then commits that stale
+                    // buffer before any configure, and the compositor
+                    // kills the client -- wl_display error 2,
+                    // layer_surface has never been configured.
+                    // unrealize() forces a fresh wl_surface next time.
+                    // Same call gtk4-layer-shell uses in its own remap.
+                    // The cast is REQUIRED: GtkWindow implements GtkNative,
+                    // so a bare unrealize() binds to gtk_native_unrealize,
+                    // an internal vfunc, not gtk_widget_unrealize. Verified
+                    // by inspecting the C valac emits for each spelling.
+                    ((Gtk.Widget) this).unrealize();
                     PreviewCache.get_default().clear();
                     hidden();
                     // The overview just freed its grid widgets, icon textures
@@ -434,6 +450,10 @@ namespace Singularity {
 
         private void finish_gesture_hide() {
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
             PreviewCache.get_default().clear();
             hidden();
             Singularity.trim_heap();

--- a/src/components/overview/overview.vala
+++ b/src/components/overview/overview.vala
@@ -333,23 +333,7 @@ namespace Singularity {
                 _anim_out_timer = GLib.Timeout.add(180, () => {
                     _anim_out_timer = 0;
                     main_box.remove_css_class("animating-out");
-                    hide();
-                    // Drop the GdkSurface, do not merely unmap it.
-                    // GTK reuses one wl_surface across hide/show, and
-                    // gtk4-layer-shell builds a fresh layer surface over
-                    // it on the next open. A frame queued by the closing
-                    // animation can land after the unmap and re-attach a
-                    // live buffer; the next open then commits that stale
-                    // buffer before any configure, and the compositor
-                    // kills the client -- wl_display error 2,
-                    // layer_surface has never been configured.
-                    // unrealize() forces a fresh wl_surface next time.
-                    // Same call gtk4-layer-shell uses in its own remap.
-                    // The cast is REQUIRED: GtkWindow implements GtkNative,
-                    // so a bare unrealize() binds to gtk_native_unrealize,
-                    // an internal vfunc, not gtk_widget_unrealize. Verified
-                    // by inspecting the C valac emits for each spelling.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     PreviewCache.get_default().clear();
                     hidden();
                     // The overview just freed its grid widgets, icon textures
@@ -449,11 +433,7 @@ namespace Singularity {
         }
 
         private void finish_gesture_hide() {
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
             PreviewCache.get_default().clear();
             hidden();
             Singularity.trim_heap();

--- a/src/components/overview/workspace_overview.vala
+++ b/src/components/overview/workspace_overview.vala
@@ -135,11 +135,7 @@ namespace Singularity {
             wp_manager.wallpaper_changed.connect(update_wallpaper);
             update_wallpaper();
 
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
         }
 
         private void update_wallpaper() {
@@ -424,11 +420,7 @@ namespace Singularity {
                     _anim_out_timer = 0;
                     opacity = 0;
                     anim_box.remove_css_class("animating-out");
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     // Free all window preview textures - they'll be re-captured on next open
                     clear_overview_content();
                     hidden();
@@ -506,11 +498,7 @@ namespace Singularity {
                     || Math.fabs(opacity - target) < 0.001) {
                 opacity = target;
                 if (!stay_open) {
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     clear_overview_content();
                     hidden();
                 }
@@ -529,11 +517,7 @@ namespace Singularity {
                 opacity = target;
                 if (_gesture_animation == animation) _gesture_animation = null;
                 if (!stay_open) {
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                     clear_overview_content();
                     hidden();
                 }

--- a/src/components/overview/workspace_overview.vala
+++ b/src/components/overview/workspace_overview.vala
@@ -136,6 +136,10 @@ namespace Singularity {
             update_wallpaper();
 
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
         }
 
         private void update_wallpaper() {
@@ -421,6 +425,10 @@ namespace Singularity {
                     opacity = 0;
                     anim_box.remove_css_class("animating-out");
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     // Free all window preview textures - they'll be re-captured on next open
                     clear_overview_content();
                     hidden();
@@ -499,6 +507,10 @@ namespace Singularity {
                 opacity = target;
                 if (!stay_open) {
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     clear_overview_content();
                     hidden();
                 }
@@ -518,6 +530,10 @@ namespace Singularity {
                 if (_gesture_animation == animation) _gesture_animation = null;
                 if (!stay_open) {
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                     clear_overview_content();
                     hidden();
                 }

--- a/src/components/sidebar/sidebar.vala
+++ b/src/components/sidebar/sidebar.vala
@@ -75,11 +75,7 @@ namespace Singularity {
                 toggle_settings();
             });
             system_view.hide_sidebar.connect(() => {
-                hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
             });
             system_view.open_settings_page.connect((page) => {
                 open_page(page);
@@ -94,11 +90,7 @@ namespace Singularity {
             main_stack.notify["visible-child-name"].connect(() => update_vertical_anchor());
             update_vertical_anchor();
 
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
 
             // Close on Escape key
             var key_controller = new Gtk.EventControllerKey();
@@ -106,11 +98,7 @@ namespace Singularity {
                 if (keyval == Gdk.Key.Escape) {
                     if (!Singularity.DebugManager.get_default().sidebar_pinned) {
                         desktop_settings.set_boolean("bar-layout-edit-mode", false);
-                        hide();
-                        // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                        // Cast required: GtkWindow implements GtkNative, so a bare
-                        // unrealize() binds to gtk_native_unrealize, not the widget one.
-                        ((Gtk.Widget) this).unrealize();
+                        close_layer_window (this);
                     }
                     return true;
                 }
@@ -145,11 +133,7 @@ namespace Singularity {
                 _can_close_on_focus_loss = false;
                 opacity = 1;
                 GtkLayerShell.set_margin(this, GtkLayerShell.Edge.RIGHT, 40);
-                hide();
-                // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                // Cast required: GtkWindow implements GtkNative, so a bare
-                // unrealize() binds to gtk_native_unrealize, not the widget one.
-                ((Gtk.Widget) this).unrealize();
+                close_layer_window (this);
                 return;
             }
             // Null before skip so old done handler sees slide_animation != old_anim
@@ -171,11 +155,7 @@ namespace Singularity {
                     slide_animation = null;
                     _is_closing = false;
                     _can_close_on_focus_loss = false;
-                    hide();
-                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
-                    // Cast required: GtkWindow implements GtkNative, so a bare
-                    // unrealize() binds to gtk_native_unrealize, not the widget one.
-                    ((Gtk.Widget) this).unrealize();
+                    close_layer_window (this);
                 }
             });
             anim.play();

--- a/src/components/sidebar/sidebar.vala
+++ b/src/components/sidebar/sidebar.vala
@@ -76,6 +76,10 @@ namespace Singularity {
             });
             system_view.hide_sidebar.connect(() => {
                 hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
             });
             system_view.open_settings_page.connect((page) => {
                 open_page(page);
@@ -91,6 +95,10 @@ namespace Singularity {
             update_vertical_anchor();
 
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
 
             // Close on Escape key
             var key_controller = new Gtk.EventControllerKey();
@@ -99,6 +107,10 @@ namespace Singularity {
                     if (!Singularity.DebugManager.get_default().sidebar_pinned) {
                         desktop_settings.set_boolean("bar-layout-edit-mode", false);
                         hide();
+                        // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                        // Cast required: GtkWindow implements GtkNative, so a bare
+                        // unrealize() binds to gtk_native_unrealize, not the widget one.
+                        ((Gtk.Widget) this).unrealize();
                     }
                     return true;
                 }
@@ -134,6 +146,10 @@ namespace Singularity {
                 opacity = 1;
                 GtkLayerShell.set_margin(this, GtkLayerShell.Edge.RIGHT, 40);
                 hide();
+                // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) this).unrealize();
                 return;
             }
             // Null before skip so old done handler sees slide_animation != old_anim
@@ -156,6 +172,10 @@ namespace Singularity {
                     _is_closing = false;
                     _can_close_on_focus_loss = false;
                     hide();
+                    // Drop the GdkSurface so the next open gets a fresh wl_surface.
+                    // Cast required: GtkWindow implements GtkNative, so a bare
+                    // unrealize() binds to gtk_native_unrealize, not the widget one.
+                    ((Gtk.Widget) this).unrealize();
                 }
             });
             anim.play();

--- a/src/core/hot_corner_manager.vala
+++ b/src/core/hot_corner_manager.vala
@@ -225,6 +225,10 @@ namespace Singularity {
 
             set_child(hint);
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
         }
 
         public void show_hint(string action) {
@@ -236,6 +240,10 @@ namespace Singularity {
         public void hide_hint() {
             hint.remove_css_class("visible");
             hide();
+            // Drop the GdkSurface so the next open gets a fresh wl_surface.
+            // Cast required: GtkWindow implements GtkNative, so a bare
+            // unrealize() binds to gtk_native_unrealize, not the widget one.
+            ((Gtk.Widget) this).unrealize();
         }
 
         private static string icon_for_action(string? action) {

--- a/src/core/hot_corner_manager.vala
+++ b/src/core/hot_corner_manager.vala
@@ -224,11 +224,7 @@ namespace Singularity {
             hint.add_overlay(badge);
 
             set_child(hint);
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
         }
 
         public void show_hint(string action) {
@@ -239,11 +235,7 @@ namespace Singularity {
 
         public void hide_hint() {
             hint.remove_css_class("visible");
-            hide();
-            // Drop the GdkSurface so the next open gets a fresh wl_surface.
-            // Cast required: GtkWindow implements GtkNative, so a bare
-            // unrealize() binds to gtk_native_unrealize, not the widget one.
-            ((Gtk.Widget) this).unrealize();
+            close_layer_window (this);
         }
 
         private static string icon_for_action(string? action) {

--- a/src/core/layer_window.vala
+++ b/src/core/layer_window.vala
@@ -1,0 +1,37 @@
+using Gtk;
+
+namespace Singularity {
+
+    /**
+     * Hide a layer-shell window and drop its GdkSurface.
+     *
+     * GTK keeps one wl_surface alive across hide/show, while gtk4-layer-shell
+     * destroys the zwlr_layer_surface_v1 at unmap and creates a NEW one over
+     * that same wl_surface on the next open. wl_surface state is persistent, so
+     * a frame that lands after the unmap leaves a buffer attached, and creating
+     * a layer surface over a surface that still holds a buffer is a client
+     * error the compositor answers by killing the connection:
+     *
+     *     Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display
+     *     zwlr_layer_surface_v1 has never been configured
+     *
+     * Whether the stray frame lands is a race on wl_buffer.release, which is
+     * why a window would survive a variable number of open/close cycles before
+     * dying. Dropping the GdkSurface means the next open allocates a fresh
+     * wl_surface that cannot carry a stale buffer.
+     *
+     * This is the same sequence gtk4-layer-shell performs internally in
+     * gtk_layer_surface_remap(), so it is a supported, exercised path.
+     * unrealize() on a never-realized widget is a documented no-op, which makes
+     * this safe to call from a constructor-time hide.
+     *
+     * The cast matters: GtkWindow implements GtkNative, so a bare unrealize()
+     * binds to gtk_native_unrealize -- an internal vfunc -- rather than
+     * gtk_widget_unrealize. Verified by inspecting the C that valac emits for
+     * each spelling.
+     */
+    public void close_layer_window (Gtk.Window window) {
+        ((Gtk.Widget) window).hide ();
+        ((Gtk.Widget) window).unrealize ();
+    }
+}

--- a/src/core/main.vala
+++ b/src/core/main.vala
@@ -760,7 +760,16 @@ public class SingularityApp : Singularity.ShellApplication, Singularity.Shell.Sh
 
     private void sync_bar_layout_edit_mode() {
         if (settings.get_boolean("bar-layout-edit-mode")) {
-            sidebar?.hide();
+            if (sidebar != null) {
+                sidebar.hide();
+                // Drop the GdkSurface here too. This is the one close path that
+                // lives OUTSIDE Sidebar, so the in-class resets do not cover it,
+                // and re-opening via a panel or dock toggle calls present() on
+                // the old surface -- the same stale-buffer fault.
+                // Cast required: GtkWindow implements GtkNative, so a bare
+                // unrealize() binds to gtk_native_unrealize, not the widget one.
+                ((Gtk.Widget) sidebar).unrealize();
+            }
             settings_window?.hide();
             if (bar_layout_edit_overlay == null) {
                 bar_layout_edit_overlay = new Singularity.BarLayoutEditOverlay(this);


### PR DESCRIPTION
## Summary

Every layer-shell window in the shell can be killed by the compositor after a variable number of open/close cycles:

```
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
wl_display error 2: zwlr_layer_surface_v1 has never been configured
```

## Root cause

GTK keeps ONE `wl_surface` alive across hide/show. gtk4-layer-shell destroys the `zwlr_layer_surface_v1` at unmap and creates a NEW one over that same surface on the next open. Comparing a working cycle with a crashing one in a single session:

```
working  (#77 -> #64)          crashing (#64 -> #82)
destroy()                      destroy()
attach(nil); commit()          attach(nil); commit()
<nothing>                      attach(wl_buffer#79); commit()   <-- stray
get_layer_surface(#64)         get_layer_surface(#82)
commit() -> configure OK       commit() -> ERROR 2
```

The only difference is a frame queued by the closing animation landing ~0.7 ms after the unmap, re-attaching a live buffer to the now-roleless surface. `wl_surface` state is persistent, so that buffer is still current when the next layer surface is created, and its first commit carries a buffer before any configure — which wlroots rejects. Whether that frame lands is a race on `wl_buffer.release`, which is why windows died after a *variable* number of opens.

## The change

`close_layer_window()` in `src/core/layer_window.vala` hides the window and drops its `GdkSurface`, so the next open allocates a fresh `wl_surface` that cannot carry a stale buffer. This is the same sequence gtk4-layer-shell performs internally in `gtk_layer_surface_remap()`.

All 24 close paths across six files call that one helper — the rationale lives once, next to the code that implements it, rather than being repeated at each site:

```
dock.vala                 7
sidebar.vala              5
app_menu.vala             4
workspace_overview.vala   4
hot_corner_manager.vala   2
overview.vala             2
```

The cast inside the helper is required: `GtkWindow` implements `GtkNative`, so a bare `unrealize()` binds to `gtk_native_unrealize`, an internal vfunc, not `gtk_widget_unrealize`. Verified by inspecting the C valac emits for each spelling.

## Validation

Verified with a Wayland trace analyser that flags a layer surface being re-created over a `wl_surface` that still holds a buffer: **1 dangerous re-creation before the change, 0 across 36 layer surfaces after it.** Confirmed by hand over ~30 open cycles and across a clean reboot, with zero shell restarts. CIX Sky1, labwc/wlroots, GTK4, GLES on Mali.

Every one of the 24 sites resolves to a `Gtk.Window`: two are in `hot_corner_manager.vala`, whose first class is `HotCornerManager : Object`, but both sit inside `HotCornerHintWindow : Gtk.Window` later in the file; `overview.vala` similarly contains a `WorkspaceCard : Gtk.Box` and no call site falls inside it.

## Upstream

The underlying protocol error is reproducible without this shell — two layer windows cycling, with the unmap dispatched after a paint is queued, fails 5/5 within four layer surfaces on stock gtk4-layer-shell 1.3.0. Reproducer and analysis: wmww/gtk4-layer-shell#130. If that lands, this workaround becomes unnecessary.
