### PR TITLE
fix(displays): never offer a scale below 1.0, and clamp what is loaded

### DIFF
--- a/src/components/sidebar/pages/displays_page.vala
+++ b/src/components/sidebar/pages/displays_page.vala
@@ -101,7 +101,7 @@ namespace Singularity.SidebarPages {
             scale_lbl.add_css_class("title");
             scale_lbl.halign = Align.START;
             scale_box.append(scale_lbl);
-            scale_scale = new Scale.with_range(Orientation.HORIZONTAL, 0.5, 3.0, 0.25);
+            scale_scale = new Scale.with_range(Orientation.HORIZONTAL, 1.0, 3.0, 0.25);
             scale_scale.draw_value = true;
             scale_scale.hexpand = true;
             scale_scale.value_changed.connect(() => {

--- a/src/core/display_manager.vala
+++ b/src/core/display_manager.vala
@@ -6,6 +6,23 @@ namespace Singularity {
 
     public class DisplayManager : Object {
         private static DisplayManager? _instance;
+
+        // A wl_output can only advertise an INTEGER scale, so a fractional value
+        // below 1.0 does not make the UI smaller -- it enlarges the logical
+        // desktop beyond the panel's native size while clients are told "scale
+        // 1", so everything renders undersized, including the settings page that
+        // would undo it. Clamp anything read back from disk (written by an older
+        // build, or edited by hand) into a range that can actually be represented.
+        private const double MIN_SCALE = 1.0;
+        private const double MAX_SCALE = 3.0;
+
+        private static double clamp_scale(double value) {
+            // The negated comparison also rejects NaN, which would otherwise
+            // propagate into the compositor configuration.
+            if (!(value >= MIN_SCALE)) return MIN_SCALE;
+            if (value > MAX_SCALE) return MAX_SCALE;
+            return value;
+        }
         public struct Mode {
             public int width;
             public int height;
@@ -319,7 +336,7 @@ namespace Singularity {
                         if (m.name == name) {
                             m.x = (int)obj.get_int_member("x");
                             m.y = (int)obj.get_int_member("y");
-                            m.scale = obj.get_double_member("scale");
+                            m.scale = clamp_scale(obj.get_double_member("scale"));
                             m.transform = (int)obj.get_int_member("transform");
                             m.enabled = obj.get_boolean_member("enabled");
                             if (obj.has_member("vrr_enabled")) m.vrr_enabled = obj.get_boolean_member("vrr_enabled");

--- a/src/core/display_manager.vala
+++ b/src/core/display_manager.vala
@@ -24,6 +24,57 @@ namespace Singularity {
         private const double MIN_SCALE = 1.0;
         private const double MAX_SCALE = 16.0;
 
+        /**
+         * A sensible starting scale for a display that has no saved setting.
+         *
+         * Without this a fresh install comes up at 1.0 on every panel, which on
+         * a high-DPI screen means an unreadably small UI and sends the user
+         * straight to the scale slider. The physical size needed to compute it
+         * is already reported by wl_output and was previously stored and never
+         * read.
+         *
+         * Returns 1.0 whenever the DPI cannot be trusted: many outputs report a
+         * physical size of 0x0 (and projectors/TVs report sizes that are honest
+         * but irrelevant), so the fallback has to be the safe one.
+         */
+        public static double dpi_default_scale(int phys_w_mm, int phys_h_mm, int px_w, int px_h) {
+            if (phys_w_mm <= 0 || phys_h_mm <= 0 || px_w <= 0 || px_h <= 0) {
+                return 1.0;
+            }
+            double diag_mm = Math.sqrt((double) phys_w_mm * phys_w_mm
+                                     + (double) phys_h_mm * phys_h_mm);
+            double diag_in = diag_mm / 25.4;
+            if (diag_in < 1.0) return 1.0;
+            double diag_px = Math.sqrt((double) px_w * px_w + (double) px_h * px_h);
+            double dpi = diag_px / diag_in;
+
+            // Fractional steps are deliberate -- 4K/27" lands near 163 dpi, where
+            // 2.0 is too large and 1.0 too small.
+            if (dpi >= 192.0) return 2.0;
+            if (dpi >= 168.0) return 1.75;
+            if (dpi >= 144.0) return 1.5;
+            if (dpi >= 120.0) return 1.25;
+            return 1.0;
+        }
+
+        private void apply_dpi_defaults() {
+            foreach (var m in monitors) {
+                if (m.scale_from_config) continue;
+                int pw = 0, ph = 0;
+                if (m.current_mode != null) {
+                    pw = m.current_mode.width;
+                    ph = m.current_mode.height;
+                }
+                double d = dpi_default_scale(m.phys_width, m.phys_height, pw, ph);
+                if (d != m.scale) {
+                    message("DisplayManager: %s has no saved scale, defaulting to %.2f "
+                            + "(%dx%d px, %dx%d mm)", m.name, d, pw, ph,
+                            m.phys_width, m.phys_height);
+                    m.scale = d;
+                }
+            }
+        }
+
         private static double clamp_scale(double value) {
             // The negated comparison also rejects NaN, which would otherwise
             // propagate into the compositor configuration.
@@ -49,6 +100,9 @@ namespace Singularity {
             public int x;
             public int y;
             public double scale;
+            // True once a saved scale has been restored for this output, so the
+            // DPI-derived default does not overwrite a deliberate choice.
+            public bool scale_from_config;
             public int transform;
             public bool enabled;
             public bool vrr_supported { get; set; default = false; }
@@ -309,7 +363,12 @@ namespace Singularity {
 
         public void load_and_apply_saved() {
             string path = config_path();
-            if (!GLib.FileUtils.test(path, GLib.FileTest.EXISTS)) return;
+            if (!GLib.FileUtils.test(path, GLib.FileTest.EXISTS)) {
+                // First boot: nothing saved, so every output takes the default.
+                apply_dpi_defaults();
+                apply_configuration();
+                return;
+            }
             try {
                 var parser = new Json.Parser();
                 parser.load_from_file(path);
@@ -346,6 +405,7 @@ namespace Singularity {
                             m.x = (int)obj.get_int_member("x");
                             m.y = (int)obj.get_int_member("y");
                             m.scale = clamp_scale(obj.get_double_member("scale"));
+                            m.scale_from_config = true;
                             m.transform = (int)obj.get_int_member("transform");
                             m.enabled = obj.get_boolean_member("enabled");
                             if (obj.has_member("vrr_enabled")) m.vrr_enabled = obj.get_boolean_member("vrr_enabled");
@@ -364,6 +424,10 @@ namespace Singularity {
                         }
                     }
                 }
+                // An output the config has never seen (new monitor, or a config
+                // written before this display was attached) is still a fresh
+                // display and gets the DPI default rather than a flat 1.0.
+                apply_dpi_defaults();
                 message("DisplayManager: loaded saved config from %s", path);
                 apply_configuration();
             } catch (GLib.Error e) {

--- a/src/core/display_manager.vala
+++ b/src/core/display_manager.vala
@@ -11,18 +11,27 @@ namespace Singularity {
         // below 1.0 does not make the UI smaller -- it enlarges the logical
         // desktop beyond the panel's native size while clients are told "scale
         // 1", so everything renders undersized, including the settings page that
-        // would undo it. Clamp anything read back from disk (written by an older
-        // build, or edited by hand) into a range that can actually be represented.
+        // would undo it.
+        //
+        // MAX_SCALE is a protocol sanity ceiling, NOT the settings slider's
+        // range. Integer scales above the slider maximum (4 and up) are
+        // representable and are legitimately used on very high-DPI panels and
+        // for accessibility, so they are passed through. But the value reaches
+        // wl_fixed_from_double() in apply_configuration(), and wl_fixed is 24.8
+        // fixed point: a non-finite or absurdly large value -- from a
+        // hand-edited displays.json or a misbehaving compositor -- cannot be
+        // represented and would overflow into a bad output configuration.
         private const double MIN_SCALE = 1.0;
-        private const double MAX_SCALE = 3.0;
+        private const double MAX_SCALE = 16.0;
 
         private static double clamp_scale(double value) {
             // The negated comparison also rejects NaN, which would otherwise
             // propagate into the compositor configuration.
             if (!(value >= MIN_SCALE)) return MIN_SCALE;
-            if (value > MAX_SCALE) return MAX_SCALE;
+            if (!(value <= MAX_SCALE)) return MAX_SCALE;  // also catches +inf
             return value;
         }
+
         public struct Mode {
             public int width;
             public int height;
@@ -110,7 +119,7 @@ namespace Singularity {
                     m.x = x;
                     m.y = y;
                     m.transform = transform;
-                    m.scale = scale;
+                    m.scale = clamp_scale(scale);
                     m.enabled = enabled;
                     monitors_changed();
                     return;


### PR DESCRIPTION
Addresses findings 1, 2 and 3 from singularityos-lab/singularity-desktop#237.

## Why a scale below 1.0 is not "smaller"

A `wl_output` can only advertise an **integer** scale. A fractional value below 1.0 does not shrink the UI — it *enlarges* the logical desktop past the panel's native size, wlroots clamps the advertised scale to 1, and clients draw 1:1 into that oversized space. Everything renders undersized, **including the settings page holding the slider that would undo it**.

Measured on a 3840×2160 panel at scale 0.5:

```
wlr-randr          : 0.500000        <- the requested fractional scale
wl_output (client) : scale 1         <- wlroots clamps to an integer
grim capture       : 7680x4320       <- the actual logical desktop
```

All three readings are individually correct; they report different things, which is what made it confusing to diagnose.

## The changes

**1. Slider lower bound 0.5 → 1.0** (`displays_page.vala`) so the unrepresentable range is unreachable.

**2. Clamp on ingest, both paths** (`display_manager.vala`). Clamping only the `displays.json` load path was not enough: a scale below 1.0 also arrives straight from the compositor via `handle_update_head()`, which stored it unchanged. The slider then displayed a clamped value while `selected_monitor.scale` kept the bad one, and any later apply re-submitted it through `wayland_config_head_v2()`. Both routes into the model are now covered.

**3. DPI-derived default** (`dpi_default_scale()`). A fresh install came up at 1.0 on every panel, so a high-DPI screen gave an unreadably small UI out of the box — and `phys_width`/`phys_height` were already being stored and never read. The default is now computed from the reported physical size and current mode: 1.0 / 1.25 / 1.5 / 1.75 / 2.0. Fractional steps are deliberate, since 4K at 27" is ~163 dpi where 2.0 is too large and 1.0 too small.

It applies only where nothing was saved — `scale_from_config` marks outputs restored from `displays.json`, so a deliberate choice is never overwritten. It also covers a newly attached output and the case where `displays.json` does not exist at all. It returns 1.0 whenever the DPI cannot be trusted: many outputs report a physical size of 0×0, and TVs/projectors report sizes that are honest but irrelevant.

## On the upper bound

`MAX_SCALE` is a protocol sanity ceiling, not a UI limit. Integer scales above the slider's range are representable and legitimately used on very high-DPI panels and for accessibility, so a persisted value above the slider maximum passes through untouched. But the value reaches `wl_fixed_from_double()`, and `wl_fixed` is 24.8 fixed point, so a non-finite or absurdly large value from a hand-edited `displays.json` would overflow into a bad output configuration. Both comparisons are written negated (`!(value >= MIN)`, `!(value <= MAX)`) so `NaN` and `+inf` are rejected rather than propagated.

## Not included

Finding 4 (`displays.json` vs `output.xml` having no reconciliation) is a design question rather than a defect, so it stays in the issue.

## Validation

Builds clean with the shell's own valac invocation; warning count unchanged at the tree's baseline.
