### PR TITLE
shell: dismiss folder overlays when the launcher closes

### DIFF
--- a/src/components/overview/app_launcher_grid.vala
+++ b/src/components/overview/app_launcher_grid.vala
@@ -239,8 +239,7 @@ namespace Singularity {
         private uint _build_source = 0;
 
         public void populate(bool animate = false) {
-            _folder_overlays.foreach((id, ov) => ov.close_overlay());
-            _folder_overlays.remove_all();
+            close_folder_overlays();
 
             // Cancel any in-flight build + lazy widget jobs from a prior pass.
             if (_build_source != 0) { GLib.Source.remove(_build_source); _build_source = 0; }
@@ -377,9 +376,35 @@ namespace Singularity {
             return GLib.Source.CONTINUE;
         }
 
-        public void depopulate() {
-            _folder_overlays.foreach((id, ov) => ov.close_overlay());
+        /**
+         * Dismiss any open folder overlay without tearing down the grid.
+         *
+         * A folder overlay is its own toplevel layer-shell window, so hiding
+         * the launcher that spawned it leaves it on screen. Closing the
+         * overlays is cheap; dropping the grid contents is not, which is why
+         * depopulate() stays on its idle timer and this can be called
+         * immediately on close.
+         */
+        public void close_folder_overlays() {
+            // force_close(), not close_overlay(): close_overlay() fades via
+            // add_tick_callback(), the exact mechanism force_close() exists
+            // to avoid (#51) -- if the clock stalls, destroy() never runs and
+            // the overlay is stuck for good.
+            //
+            // Snapshot the table before closing anything: AppFolderOverlay's
+            // closed() signal fires synchronously and its handler removes
+            // the entry from _folder_overlays, so calling force_close()
+            // while still inside a foreach over that same table mutates it
+            // mid-iteration.
+            var overlays = _folder_overlays.get_values();
             _folder_overlays.remove_all();
+            foreach (var ov in overlays) {
+                ov.force_close();
+            }
+        }
+
+        public void depopulate() {
+            close_folder_overlays();
             Widget? c = grid.get_first_child();
             while (c != null) { Widget nc = c.get_next_sibling(); grid.remove(c); c = nc; }
         }

--- a/src/components/overview/overview.vala
+++ b/src/components/overview/overview.vala
@@ -332,6 +332,16 @@ namespace Singularity {
                 main_box.remove_css_class("animating-in");
                 main_box.add_css_class("animating-out");
                 hiding();
+                // A folder overlay is a separate toplevel layer window, so it
+                // does not go away with the launcher. Dismiss it here, next to
+                // hiding() -- not inside the 180ms timer below. Two reasons:
+                // the overlay and the launcher then leave together instead of
+                // the overlay fading alone over the desktop for the 180ms the
+                // launcher already took to close, and the reopen path above
+                // cancels _anim_out_timer when the overview reopens within
+                // that window, which would otherwise skip this dismissal
+                // entirely and leave the overlay stuck open indefinitely.
+                launcher_grid.close_folder_overlays();
                 _anim_out_timer = GLib.Timeout.add(180, () => {
                     _anim_out_timer = 0;
                     main_box.remove_css_class("animating-out");
@@ -437,6 +447,12 @@ namespace Singularity {
         }
 
         private void finish_gesture_hide() {
+            // Same reason as the animated close path, and same fix: dismiss
+            // the overlay before close_layer_window(), not after -- the
+            // overlay is its own toplevel and does not go away with the
+            // launcher, and closing it second left it fading alone over the
+            // desktop once the launcher window was already gone.
+            launcher_grid.close_folder_overlays();
             close_layer_window (this);
             PreviewCache.get_default().clear();
             hidden();


### PR DESCRIPTION
Opening an app folder creates an `AppFolderOverlay`, which is its own toplevel layer-shell window on the OVERLAY layer. Hiding the launcher does not take it down, and nothing dismisses it at close time.

The only thing that closes folder overlays is `launcher_grid.depopulate()`, and both close paths defer that to an idle timer:

```vala
private const uint IDLE_DEPOPULATE_MS = 45000;
...
_idle_depopulate_timer = GLib.Timeout.add(IDLE_DEPOPULATE_MS, () => {
    if (!is_showing) {
        launcher_grid.depopulate();   // <- the only thing that closes folder overlays
```

That timer exists to reclaim grid widgets, icon textures and preview buffers; overlay teardown is bundled into it incidentally.

So: open a folder, close the launcher, and the overlay stays on screen for **45 seconds**. Reopen the launcher inside that window and the reopen branch cancels the timer —

```vala
} else {
    if (_idle_depopulate_timer != 0) {
        GLib.Source.remove(_idle_depopulate_timer);
        _idle_depopulate_timer = 0;
    }
```

— so `depopulate()` never runs and the overlay stays up until some later close plus a full idle.

This is a sibling of #51. The comment on `force_close()` notes that the animated close "depends on frame-clock ticks that stop once the launched window takes focus, leaving the overlay stuck on screen" — same defect via the launch path; this is the close-the-launcher path.

## The fix

- `close_folder_overlays()` on `AppLauncherGrid` dismisses the overlays and nothing else.
- Both close paths in `Overview` — the animated close and `finish_gesture_hide()` — call it immediately.
- `depopulate()` keeps its idle timer and delegates the overlay half to the same helper, so the memory-reclaim behaviour is unchanged.

The overlay feature is untouched; only the moment it goes away changes.

## One question for you

If folder overlays are *meant* to outlive the launcher and persist across a close/reopen, this is working as designed and you should close it. I do not think so, since the dismissal lives in a memory-reclaim path rather than anywhere intentional — but that is your call.

Reproduced on `main`, labwc 0.9.5 / wlroots 0.20.2, GTK 4.22.4.
