### PR TITLE
fix(screenshot): resolve target monitor before opening from the control-panel button

### DIFF
--- a/src/components/sidebar/views/system_view.vala
+++ b/src/components/sidebar/views/system_view.vala
@@ -89,7 +89,15 @@ namespace Singularity {
                 var app = (Gtk.Application) GLib.Application.get_default();
                 var tool = Singularity.ScreenshotTool.get_default(app);
                 if (!tool.ensure_screenshots()) return;
-                tool.present();
+                // prepare_for_invocation() resolves _target_monitor/_target_connector
+                // and sets the layer-shell output -- without it both stay null and
+                // screen-mode capture fails with "no target monitor for screen
+                // capture" the instant this opens, since it defaults to screen mode.
+                // shortcut_manager.vala's screenshot_tool_action() (the Print-key
+                // path) already does this; this entry point never did.
+                var handle = Singularity.AppSystem.get_default().get_focused_window_handle();
+                tool.prepare_for_invocation(handle);
+                tool.open_dialog();
             });
             _edit_button = new Button.from_icon_name("document-edit-symbolic");
             _edit_button.has_frame = false;

--- a/src/core/screenshot_portal.vala
+++ b/src/core/screenshot_portal.vala
@@ -23,7 +23,10 @@ namespace Singularity {
         }
 
         public bool is_available() {
-            if (connection == null) return false;
+            if (connection == null) {
+                warning("[ScreenshotPortal] is_available: no session bus connection");
+                return false;
+            }
             try {
                 var res = connection.call_sync(
                     "org.freedesktop.DBus",
@@ -35,8 +38,12 @@ namespace Singularity {
                     DBusCallFlags.NONE, -1, null);
                 bool owned;
                 res.get("(b)", out owned);
+                if (!owned) {
+                    warning("[ScreenshotPortal] is_available: org.freedesktop.portal.Desktop has no owner");
+                }
                 return owned;
             } catch (Error e) {
+                warning("[ScreenshotPortal] is_available: NameHasOwner call failed: %s", e.message);
                 return false;
             }
         }


### PR DESCRIPTION
The control-panel camera button called `tool.present()` directly, skipping `prepare_for_invocation()` -- so `_target_monitor`/`_target_connector` stayed null and screen-mode capture always failed with "no target monitor for screen capture", surfaced as the generic "Screenshots unavailable" dialog. `shortcut_manager.vala`'s Print-key path already calls `prepare_for_invocation()` correctly; this entry point never did.

Also adds real logging to `ScreenshotPortal.is_available()`'s previously-silent failure paths -- this is what let me rule out the portal/D-Bus layer and find the actual bug.

Validated: rebuilt, deployed, restarted on real O6N hardware -- control-panel screenshot button now captures successfully.